### PR TITLE
cfg/update-sig-docs-es-OWNERS_ALIASES

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -84,11 +84,13 @@ aliases:
   sig-docs-es-owners: # Admins for Spanish content
     - electrocucaracha
     - krol3
+    - raelga
     - ramrodo
   sig-docs-es-reviews: # PR reviews for Spanish content
     - electrocucaracha
     - jossemarGT
     - krol3
+    - raelga
     - ramrodo
   sig-docs-fr-owners: # Admins for French content
     - perriea


### PR DESCRIPTION
### Description

Adds @raelga to the sig-docs-es owners and reviewer aliases as discussed in the weekly meeting.

/cc @electrocucaracha
/cc @krol3